### PR TITLE
CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(libseven C ASM)
+
+add_library(seven STATIC
+    src/hw/dma.s
+    src/hw/input.c
+    src/hw/irq.s
+    src/hw/lcd.s
+    src/hw/sram.s
+    src/hw/svc.s
+    src/hw/timer.c
+    src/util/log.c
+    src/util/mem.s
+    src/util/profile.s
+    src/util/rand.s
+    src/util/str.s
+)
+
+target_include_directories(seven PUBLIC include/)
+target_include_directories(seven PRIVATE src/)
+
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang") # Clang does not support -mthumb-interwork
+    set(flagInterwork -mthumb-interwork)
+endif()
+
+target_compile_options(seven PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:-Os -g -ffunction-sections -fdata-sections -ffreestanding -std=c99 -Wall -Wpedantic -mcpu=arm7tdmi -mthumb ${flagInterwork}>
+)
+
+# Allow the string "libseven" as a parameter for target_link_libraries
+add_library(libseven ALIAS seven)
+
+if(EXISTS $ENV{DEVKITPRO})
+    install(TARGETS seven DESTINATION "$ENV{DEVKITPRO}/libseven/lib")
+    install(DIRECTORY include/ DESTINATION "$ENV{DEVKITPRO}/libseven/include")
+    install(FILES LICENSE_SRC.txt DESTINATION "$ENV{DEVKITPRO}/libseven")
+endif()


### PR DESCRIPTION
I am a bit unsure about the `build.md` changes, so I made it a separate commit with willingness to drop.

The `CMakeLists.txt` is adapted from [gba-toolchain](https://github.com/felixjones/gba-toolchain/blob/d2081400586befd42c3954b7c3c474e3133e7a7f/cmake/LibsevenCMakeLists.cmake).

I particularly need feedback on the `build.md` changes. Technically a chunk of the information I've added belongs in the "Build" instructions, rather than "Installation". There's also a difficultly regarding communicating the need for a cross-compiling CMake toolchain file and an installation of make.

The `make` requirement can probably be resolved by adding a search for make into the `CMakeLists.txt` itself, but really this responsibility belongs in the toolchain. Another option is to remove that and force any GBA toolchains to search for `make`. (I consider this a reasonable thing to do).