### PR TITLE
CMakeLists.txt explicitly set include directories for assembler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 project(libseven C ASM)
+set(CMAKE_INCLUDE_FLAG_ASM "-Wa,-I")
 
 add_library(seven STATIC
     src/hw/dma.s


### PR DESCRIPTION
This fixes https://github.com/LunarLambda/libseven/issues/4 for builds using CMake